### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,10 +43,12 @@ class ServerlessIniEnv {
           stage: {
             usage: 'Stage of the service',
             shortcut: 's',
+            type: 'string',
           },
           function: {
             usage: 'Update a single function environments vars',
             shortcut: 'f',
+            type: 'string',
           },
         },
         commands: {
@@ -59,7 +61,8 @@ class ServerlessIniEnv {
             options: {
               function: {
                 usage: 'Name of the function',
-                shortcut: 'f'
+                shortcut: 'f',
+                type: 'string',
               },
             }
           }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessIniEnv for "stage", "function"
```